### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/push-to-kindle/troubleshooting.md
+++ b/docs/push-to-kindle/troubleshooting.md
@@ -43,6 +43,6 @@ In some cases your documents reach your Amazon Kindle account, but Amazon can't 
 
 Push to Kindle process web articles and send the resulting e-book files on your behalf to your Amazon Kindle's Send-to-Kindle address. If you suspect the issue may be with our service, rather than Amazon's end, an easy way to check is to email a small Word or PDF document as an attachment directly to your @kindle.com address (ie. not through Push to Kindle).
 
-If these show up on your Kindle, try using our Push to Kindle [web app](https://pushtokindle.fivefilters.org) and in the download panel click 'MOBI' to save the MOBI file to your computer. Then email the MOBI file as an attachment as you did before and see if that shows up.
+If these show up on your Kindle, try using our Push to Kindle [web app](https://pushtokindle.fivefilters.org) and in the download panel click 'EPUB' to save the EPUB file to your computer. Then email the EPUB file as an attachment as you did before and see if that shows up.
 
 If these steps work for you, and you've checked that your email addresses have been configured in the Push to Kindle app correctly (remember sending directly to your Kindle account uses your regular e-mail address as the 'Send From' address), then you can contact us at help@fivefilters.org for additional support.


### PR DESCRIPTION
Docs should encourage users to test with EPUB, since MOBI will be deprecated soon. I just got this from Kindle Support: "We are writing to let you know that Send to Kindle will soon remove the ability to send MOBI (.mobi, .azw) documents to your Kindle library. Any MOBI documents already in your library will not be affected by this change. MOBI is an older file format and won’t support the newest Kindle features for documents. "